### PR TITLE
Add arm64 build support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_script:
   - popd
 
 script:
-  - ./build.sh -r ${MALI_VERSION} -b
+  - ./build.sh -r ${MALI_VERSION} -z ${ARCH} -b
 
 matrix:
   include:

--- a/travis-base.yml
+++ b/travis-base.yml
@@ -35,5 +35,5 @@ before_script:
   - popd
 
 script:
-  - ./build.sh -r ${MALI_VERSION} -b
+  - ./build.sh -r ${MALI_VERSION} -z ${ARCH} -b
 


### PR DESCRIPTION
Travis now builds module using arm architecture only.
Module can be built for arm64 too.

Add -z ${ARCH} to travis script.

Signed-off-by: Giulio Benetti <giulio.benetti@micronovasrl.com>