### PR TITLE
Update the patches to be applied with fuzz 0

### DIFF
--- a/patches/r6p2/0018-mali-support-building-against-4.20.patch
+++ b/patches/r6p2/0018-mali-support-building-against-4.20.patch
@@ -1,0 +1,87 @@
+From ab90dcd9c5c33d3c26f2553f63dcd1837ce49d79 Mon Sep 17 00:00:00 2001
+From: Roman Stratiienko <roman.stratiienko@globallogic.com>
+Date: Wed, 28 Nov 2018 14:23:57 +0200
+Subject: [PATCH] mali: support building against 4.20
+
+From 4.20 kernel vm_insert_pfn was dropped
+This makes wrapper to preserve compatibility
+
+Also get_monotonic_boottime(...) was removed from 4.20
+Replace it with ktime_get_boot_ns()
+
+Signed-off-by: Roman Stratiienko <roman.stratiienko@globallogic.com>
+---
+ src/devicedrv/mali/linux/mali_kernel_linux.c | 11 +++++++++++
+ src/devicedrv/mali/linux/mali_kernel_linux.h | 10 ++++++++++
+ src/devicedrv/mali/linux/mali_osk_time.c     |  4 ++++
+ 3 files changed, 25 insertions(+)
+
+diff --git a/src/devicedrv/mali/linux/mali_kernel_linux.c b/src/devicedrv/mali/linux/mali_kernel_linux.c
+index 34cb3d7..6ed89a6 100755
+--- a/src/devicedrv/mali/linux/mali_kernel_linux.c
++++ b/src/devicedrv/mali/linux/mali_kernel_linux.c
+@@ -1125,6 +1125,17 @@
+ 	return err;
+ }
+ 
++/*
++ * From 4.20.0 kernel vm_insert_pfn was dropped
++ * Make wrapper to preserve compatibility
++ */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 20, 0)
++int vm_insert_pfn(struct vm_area_struct *vma, unsigned long addr,
++		  unsigned long pfn)
++{
++	return vm_fault_to_errno(vmf_insert_pfn(vma, addr, pfn), 0xffff);
++}
++#endif
+ 
+ module_init(mali_module_init);
+ module_exit(mali_module_exit);
+diff --git a/src/devicedrv/mali/linux/mali_kernel_linux.h b/src/devicedrv/mali/linux/mali_kernel_linux.h
+index 8548c9f..f858a5c 100755
+--- a/src/devicedrv/mali/linux/mali_kernel_linux.h
++++ b/src/devicedrv/mali/linux/mali_kernel_linux.h
+@@ -16,6 +16,7 @@
+ #endif
+ 
+ #include <linux/cdev.h>     /* character device definitions */
++#include <linux/mm.h>
+ #include <linux/idr.h>
+ #include <linux/rbtree.h>
+ #include "mali_kernel_license.h"
+@@ -33,6 +34,15 @@
+ #define __GFP_REPEAT __GFP_RETRY_MAYFAIL
+ #endif
+ 
++/*
++ * From 4.20.0 kernel vm_insert_pfn was dropped
++ * Make wrapper to preserve compatibility
++ */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 20, 0)
++extern int vm_insert_pfn(struct vm_area_struct *vma, unsigned long addr,
++			 unsigned long pfn);
++#endif
++
+ #ifdef __cplusplus
+ }
+ #endif
+diff --git a/src/devicedrv/mali/linux/mali_osk_time.c b/src/devicedrv/mali/linux/mali_osk_time.c
+index 4deaa10..a14cb7d 100755
+--- a/src/devicedrv/mali/linux/mali_osk_time.c
++++ b/src/devicedrv/mali/linux/mali_osk_time.c
+@@ -53,7 +53,11 @@ u64 _mali_osk_time_get_ns(void)
+ 
+ u64 _mali_osk_boot_time_get_ns(void)
+ {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 20, 0)
++	return ktime_get_boot_ns();
++#else
+ 	struct timespec tsval;
+ 	get_monotonic_boottime(&tsval);
+ 	return (u64)timespec_to_ns(&tsval);
++#endif
+ }
+-- 
+2.17.1
+

--- a/patches/r6p2/series
+++ b/patches/r6p2/series
@@ -14,7 +14,7 @@ r6p2/0013-mali-support-building-against-4.15.patch
 r6p2/0014-mali-Make-devfreq-optional.patch
 0015-Enable-parallel-building-passing-variable-to-Makefile.patch
 r6p2/0016-mali-support-building-against-4.16.patch
-0018-mali-support-building-against-4.20.patch
+r6p2/0018-mali-support-building-against-4.20.patch
 0019-mali-support-building-against-5.0.patch
 0020-mali-support-building-against-4.17.patch
 0021-mali-support-building-against-5.3.patch

--- a/patches/r8p1/0013-mali-support-building-against-4.15.patch
+++ b/patches/r8p1/0013-mali-support-building-against-4.15.patch
@@ -1,0 +1,127 @@
+From 5bc1f96c6e9b8927e3020fdfe58b2d99fa42bcb3 Mon Sep 17 00:00:00 2001
+From: John Stultz <john.stultz@linaro.org>
+Date: Thu, 16 Nov 2017 13:42:23 -0800
+Subject: MALI: v4.15-rc build fix
+
+Signed-off-by: John Stultz <john.stultz@linaro.org>
+---
+ src/devicedrv/mali/common/mali_control_timer.c  | 2 +-
+ src/devicedrv/mali/common/mali_group.c          | 8 +++++---
+ src/devicedrv/mali/common/mali_osk_types.h      | 8 +++++++-
+ src/devicedrv/mali/linux/mali_memory_os_alloc.c | 2 +-
+ src/devicedrv/mali/linux/mali_osk_timers.c      | 16 ++++++++++------
+ 5 files changed, 24 insertions(+), 12 deletions(-)
+
+--- a/src/devicedrv/mali/common/mali_control_timer.c
++++ b/src/devicedrv/mali/common/mali_control_timer.c
+@@ -28,7 +28,7 @@ void mali_control_timer_add(u32 timeout)
+ 	_mali_osk_timer_add(mali_control_timer, _mali_osk_time_mstoticks(timeout));
+ }
+ 
+-static void mali_control_timer_callback(void *arg)
++static void mali_control_timer_callback(struct timer_list *t)
+ {
+ 	if (mali_utilization_enabled()) {
+ 		struct mali_gpu_utilization_data *util_data = NULL;
+--- a/src/devicedrv/mali/common/mali_group.c
++++ b/src/devicedrv/mali/common/mali_group.c
+@@ -44,7 +44,7 @@
+ static void mali_group_bottom_half_mmu(void *data);
+ static void mali_group_bottom_half_gp(void *data);
+ static void mali_group_bottom_half_pp(void *data);
+-static void mali_group_timeout(void *data);
++static void mali_group_timeout(struct timer_list *t);
+ static void mali_group_reset_pp(struct mali_group *group);
+ static void mali_group_reset_mmu(struct mali_group *group);
+ 
+@@ -1761,9 +1761,11 @@
+ 				      0xFFFFFFFF, 0);
+ }
+ 
+-static void mali_group_timeout(void *data)
++static void mali_group_timeout(struct timer_list *t)
+ {
+-	struct mali_group *group = (struct mali_group *)data;
++	_mali_osk_timer_t *tim = container_of(t, _mali_osk_timer_t, timer);
++	struct mali_group *group = container_of(&tim, struct mali_group, timeout_timer);
++
+ 	MALI_DEBUG_ASSERT_POINTER(group);
+ 
+ 	MALI_DEBUG_PRINT(2, ("Group: timeout handler for %s at %u\n",
+--- a/src/devicedrv/mali/common/mali_osk_types.h
++++ b/src/devicedrv/mali/common/mali_osk_types.h
+@@ -50,6 +50,7 @@ typedef unsigned long long u64;
+ #include <linux/types.h>
+ #endif
+ 
++#include <linux/timer.h>
+ /** @brief Mali Boolean type which uses MALI_TRUE and MALI_FALSE
+   */
+ typedef unsigned long mali_bool;
+@@ -395,7 +396,12 @@ typedef struct _mali_osk_notification_t_
+  * by any callers of _mali_osk_timer_del(). Otherwise, a deadlock may occur.
+  *
+  * @param arg Function-specific data */
+-typedef void (*_mali_osk_timer_callback_t)(void *arg);
++typedef void (*_mali_osk_timer_callback_t)(struct timer_list *t);
++
++
++struct _mali_osk_timer_t_struct {
++	struct timer_list timer;
++};
+ 
+ /** @brief Private type for Timer Callback Objects */
+ typedef struct _mali_osk_timer_t_struct _mali_osk_timer_t;
+--- a/src/devicedrv/mali/linux/mali_memory_os_alloc.c
++++ b/src/devicedrv/mali/linux/mali_memory_os_alloc.c
+@@ -202,7 +202,7 @@
+ 	/* Allocate new pages, if needed. */
+ 	for (i = 0; i < remaining; i++) {
+ 		dma_addr_t dma_addr;
+-		gfp_t flags = __GFP_ZERO | __GFP_REPEAT | __GFP_NOWARN | __GFP_COLD;
++		gfp_t flags = __GFP_ZERO | __GFP_REPEAT | __GFP_NOWARN;
+ 		int err;
+ 
+ #if defined(CONFIG_ARM) && !defined(CONFIG_ARM_LPAE)
+--- a/src/devicedrv/mali/linux/mali_osk_timers.c
++++ b/src/devicedrv/mali/linux/mali_osk_timers.c
+@@ -18,16 +18,25 @@
+ #include "mali_osk.h"
+ #include "mali_kernel_common.h"
+ 
+-struct _mali_osk_timer_t_struct {
+-	struct timer_list timer;
+-};
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
++
++#define TIMER_DATA_TYPE		unsigned long
++#define TIMER_FUNC_TYPE		void (*)(TIMER_DATA_TYPE)
++
++static inline void timer_setup(struct timer_list *timer,
++			       void (*callback)(struct timer_list *),
++			       unsigned int flags)
++{
++	__setup_timer(timer, (TIMER_FUNC_TYPE)callback,
++		      (TIMER_DATA_TYPE)timer, flags);
++}
++#endif
+ 
+ typedef void (*timer_timeout_function_t)(unsigned long);
+ 
+ _mali_osk_timer_t *_mali_osk_timer_init(void)
+ {
+ 	_mali_osk_timer_t *t = (_mali_osk_timer_t *)kmalloc(sizeof(_mali_osk_timer_t), GFP_KERNEL);
+-	if (NULL != t) init_timer(&t->timer);
+ 	return t;
+ }
+ 
+@@ -65,8 +74,7 @@ mali_bool _mali_osk_timer_pending(_mali_
+ void _mali_osk_timer_setcallback(_mali_osk_timer_t *tim, _mali_osk_timer_callback_t callback, void *data)
+ {
+ 	MALI_DEBUG_ASSERT_POINTER(tim);
+-	tim->timer.data = (unsigned long)data;
+-	tim->timer.function = (timer_timeout_function_t)callback;
++	timer_setup(&tim->timer, callback, 0);
+ }
+ 
+ void _mali_osk_timer_term(_mali_osk_timer_t *tim)

--- a/patches/r8p1/0020-mali-support-building-against-4.17.patch
+++ b/patches/r8p1/0020-mali-support-building-against-4.17.patch
@@ -1,0 +1,21 @@
+mali: support building against 4.17
+
+4.17 changed the return code of the fault handler from int to vm_fault_t.
+
+The return values don't change though, so we only need to update the prototype.
+
+Signed-off-by: Maxime Ripard <maxime.ripard@bootlin.com>
+
+--- a/src/devicedrv/mali/linux/mali_memory.c
++++ b/src/devicedrv/mali/linux/mali_memory.c
+@@ -70,7 +70,9 @@
+ 	}
+ }
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
++static vm_fault_t mali_mem_vma_fault(struct vm_fault *vmf)
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
+ static int mali_mem_vma_fault(struct vm_fault *vmf)
+ #else
+ static int mali_mem_vma_fault(struct vm_area_struct *vma, struct vm_fault *vmf)

--- a/patches/r8p1/series
+++ b/patches/r8p1/series
@@ -4,14 +4,14 @@
 r6p2/0006-mali-Allow-devfreq-to-run-without-power-models.patch
 r8p1/0011-mali-support-building-against-4.13.patch
 0012-mali-support-building-against-4.14.patch
-r6p2/0013-mali-support-building-against-4.15.patch
+r8p1/0013-mali-support-building-against-4.15.patch
 r6p2/0014-mali-Make-devfreq-optional.patch
 0015-Enable-parallel-building-passing-variable-to-Makefile.patch
 r6p2/0016-mali-support-building-against-4.16.patch
 r8p1/0017-mali-support-building-against-4.9-later.patch
-0018-mali-support-building-against-4.20.patch
+r6p2/0018-mali-support-building-against-4.20.patch
 0019-mali-support-building-against-5.0.patch
-0020-mali-support-building-against-4.17.patch
+r8p1/0020-mali-support-building-against-4.17.patch
 0021-mali-support-building-against-5.3.patch
 r6p2/0022-mali-support-building-against-5.6.patch
 0023-mali-support-building-against-5.7.patch


### PR DESCRIPTION
This driver, used in Buildroot for versions r6p2 and r8p1, fails to apply some patches after the commit 8f88a644ed7d6 ("support/scripts/apply-patches.sh: set the maximum fuzz factor to 0") has been merged.

This commit fixes those patches so that they can be applied with fuzz factor 0, without causing regressions for any of the Mali versions, including those not used in Buildroot.