### PR TITLE
mali: remove extra semicolon calling shrinker_alloc

### DIFF
--- a/patches/0029-Fix-build-failure-with-Linux-6.7.0.patch
+++ b/patches/0029-Fix-build-failure-with-Linux-6.7.0.patch
@@ -42,7 +42,7 @@ index 8c09578..76ec8cf 100755
  
 -#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0)
 +#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0)
-+	mali_mem_os_allocator.shrinker = shrinker_alloc(0, "mali");;
++	mali_mem_os_allocator.shrinker = shrinker_alloc(0, "mali");
 +
 +	if (NULL == mali_mem_os_allocator.shrinker) {
 +		destroy_workqueue(mali_mem_os_allocator.wq);


### PR DESCRIPTION
There are two semicolons when calling shrinker_alloc but only one is needed.

Fixes: 26c819ca3b1f ("mali: use dynamic allocated shrinker for Linux 6.7 or newer")